### PR TITLE
Lazy load databases

### DIFF
--- a/core/src/test/java/tanin/backdoor/clickhouse/ExecuteTest.java
+++ b/core/src/test/java/tanin/backdoor/clickhouse/ExecuteTest.java
@@ -9,6 +9,9 @@ public class ExecuteTest extends Base {
   @Test
   void runExplain() throws InterruptedException {
     go("/");
+    click(tid("database-item", "clickhouse"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item", "clickhouse")).getDomAttribute("data-database-status")));
+
     fillCodeMirror("explain select 1");
     select(tid("run-sql-database-select"), "clickhouse");
     click(tid("run-sql-button"));
@@ -29,6 +32,9 @@ public class ExecuteTest extends Base {
   @Test
   void updateSql() throws InterruptedException {
     go("/");
+    click(tid("database-item", "clickhouse"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item", "clickhouse")).getDomAttribute("data-database-status")));
+
     fillCodeMirror("alter table project_setting update some_value = '123' where user_id = 'user_2'");
     select(tid("run-sql-database-select"), "clickhouse");
     click(tid("run-sql-button"));
@@ -52,6 +58,9 @@ public class ExecuteTest extends Base {
   @Test
   void deleteSql() throws InterruptedException {
     go("/");
+    click(tid("database-item", "clickhouse"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item", "clickhouse")).getDomAttribute("data-database-status")));
+
     fillCodeMirror("alter table project_setting delete where user_id = 'user_2'");
     select(tid("run-sql-database-select"), "clickhouse");
     click(tid("run-sql-button"));
@@ -75,6 +84,9 @@ public class ExecuteTest extends Base {
   @Test
   void makeViewAndThenExecute() throws InterruptedException {
     go("/");
+    click(tid("database-item", "clickhouse"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item", "clickhouse")).getDomAttribute("data-database-status")));
+
     fillCodeMirror("select 1");
     select(tid("run-sql-database-select"), "clickhouse");
     click(tid("run-sql-button"));

--- a/core/src/test/java/tanin/backdoor/clickhouse/QueryTest.java
+++ b/core/src/test/java/tanin/backdoor/clickhouse/QueryTest.java
@@ -9,6 +9,9 @@ public class QueryTest extends Base {
   @Test
   void createRenameUpdateDeleteView() throws InterruptedException {
     go("/");
+    click(tid("database-item", "clickhouse"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item", "clickhouse")).getDomAttribute("data-database-status")));
+
     fillCodeMirror("select * from \"project_setting\" order by user_id asc limit 1");
     select(tid("run-sql-database-select"), "clickhouse");
     click(tid("run-sql-button"));
@@ -62,6 +65,9 @@ public class QueryTest extends Base {
   @Test
   void makeNewSql() throws InterruptedException {
     go("/");
+    click(tid("database-item", "clickhouse"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item", "clickhouse")).getDomAttribute("data-database-status")));
+
     fillCodeMirror("select 1");
     select(tid("run-sql-database-select"), "clickhouse");
     click(tid("run-sql-button"));

--- a/core/src/test/java/tanin/backdoor/clickhouse/TableTest.java
+++ b/core/src/test/java/tanin/backdoor/clickhouse/TableTest.java
@@ -48,6 +48,9 @@ public class TableTest extends Base {
       );
     }
     go("/");
+    click(tid("database-item", "clickhouse"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item", "clickhouse")).getDomAttribute("data-database-status")));
+
 
     click(tid("menu-items", "clickhouse", null, "menu-item-table", "date_time"));
 
@@ -108,6 +111,9 @@ public class TableTest extends Base {
     }
 
     go("/");
+    click(tid("database-item", "clickhouse"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item", "clickhouse")).getDomAttribute("data-database-status")));
+
 
     click(tid("menu-items", "clickhouse", null, "menu-item-table", "json_test"));
 
@@ -123,6 +129,9 @@ public class TableTest extends Base {
   @Test
   void createUpdateDropTable() throws InterruptedException {
     go("/");
+    click(tid("database-item", "clickhouse"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item", "clickhouse")).getDomAttribute("data-database-status")));
+
 
     click(tid("menu-items", "clickhouse", null, "menu-item-table", "project_setting"));
 
@@ -149,6 +158,9 @@ public class TableTest extends Base {
   @Test
   void editField() throws InterruptedException {
     go("/");
+    click(tid("database-item", "clickhouse"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item", "clickhouse")).getDomAttribute("data-database-status")));
+
 
     click(tid("menu-items", "clickhouse", null, "menu-item-table", "project_setting"));
 
@@ -167,6 +179,9 @@ public class TableTest extends Base {
   @Test
   void deleteRow() throws InterruptedException {
     go("/");
+    click(tid("database-item", "clickhouse"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item", "clickhouse")).getDomAttribute("data-database-status")));
+
 
     click(tid("menu-items", "clickhouse", null, "menu-item-table", "project_setting"));
 
@@ -185,6 +200,9 @@ public class TableTest extends Base {
   @Test
   void filterRow() throws InterruptedException {
     go("/");
+    click(tid("database-item", "clickhouse"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item", "clickhouse")).getDomAttribute("data-database-status")));
+
 
     click(tid("menu-items", "clickhouse", null, "menu-item-table", "project_setting"));
 
@@ -201,6 +219,9 @@ public class TableTest extends Base {
   @Test
   void sortRow() throws InterruptedException {
     go("/");
+    click(tid("database-item", "clickhouse"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item", "clickhouse")).getDomAttribute("data-database-status")));
+
 
     click(tid("menu-items", "clickhouse", null, "menu-item-table", "project_setting"));
 
@@ -256,6 +277,8 @@ public class TableTest extends Base {
     }
 
     go("/");
+    click(tid("database-item", "clickhouse"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item", "clickhouse")).getDomAttribute("data-database-status")));
 
     click(tid("menu-items", "clickhouse", null, "menu-item-table", "project_setting"));
     click(tid("sheet-view-column-header", "some_value", null, "sort-button"));

--- a/core/src/test/java/tanin/backdoor/postgres/ExecuteTest.java
+++ b/core/src/test/java/tanin/backdoor/postgres/ExecuteTest.java
@@ -9,6 +9,9 @@ public class ExecuteTest extends Base {
   @Test
   void runExplain() throws InterruptedException {
     go("/");
+    click(tid("database-item"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item")).getDomAttribute("data-database-status")));
+
     fillCodeMirror("explain select 1");
     click(tid("run-sql-button"));
 
@@ -26,6 +29,9 @@ public class ExecuteTest extends Base {
   @Test
   void updateSql() throws InterruptedException {
     go("/");
+    click(tid("database-item"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item")).getDomAttribute("data-database-status")));
+
     fillCodeMirror("update \"user\" set username = 'test_user_3_updated' where username = 'test_user_3'");
     click(tid("run-sql-button"));
 
@@ -51,6 +57,9 @@ public class ExecuteTest extends Base {
   @Test
   void deleteSql() throws InterruptedException {
     go("/");
+    click(tid("database-item"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item")).getDomAttribute("data-database-status")));
+
     fillCodeMirror("delete from \"user\" where username = 'test_user_3'");
     click(tid("run-sql-button"));
 
@@ -75,6 +84,9 @@ public class ExecuteTest extends Base {
   @Test
   void makeViewAndThenExecute() throws InterruptedException {
     go("/");
+    click(tid("database-item"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item")).getDomAttribute("data-database-status")));
+
     fillCodeMirror("select 1");
     click(tid("run-sql-button"));
 

--- a/core/src/test/java/tanin/backdoor/postgres/QueryTest.java
+++ b/core/src/test/java/tanin/backdoor/postgres/QueryTest.java
@@ -9,6 +9,9 @@ public class QueryTest extends Base {
   @Test
   void createRenameUpdateDeleteView() throws InterruptedException {
     go("/");
+    click(tid("database-item"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item")).getDomAttribute("data-database-status")));
+
     fillCodeMirror("select * from \"user\" order by id asc limit 1");
     click(tid("run-sql-button"));
 
@@ -59,6 +62,9 @@ public class QueryTest extends Base {
   @Test
   void makeNewSql() throws InterruptedException {
     go("/");
+    click(tid("database-item"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item")).getDomAttribute("data-database-status")));
+
     fillCodeMirror("select 1");
     click(tid("run-sql-button"));
 

--- a/core/src/test/java/tanin/backdoor/postgres/TableTest.java
+++ b/core/src/test/java/tanin/backdoor/postgres/TableTest.java
@@ -45,6 +45,9 @@ public class TableTest extends Base {
       );
     }
     go("/");
+    click(tid("database-item"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item")).getDomAttribute("data-database-status")));
+
 
     click(tid("menu-items", "postgres", null, "menu-item-table", "date_time"));
 
@@ -114,6 +117,9 @@ public class TableTest extends Base {
     }
 
     go("/");
+    click(tid("database-item"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item")).getDomAttribute("data-database-status")));
+
 
     click(tid("menu-items", "postgres", null, "menu-item-table", "json_pgvector"));
 
@@ -141,6 +147,9 @@ public class TableTest extends Base {
   @Test
   void createUpdateDropTable() throws InterruptedException {
     go("/");
+    click(tid("database-item"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item")).getDomAttribute("data-database-status")));
+
 
     click(tid("menu-items", "postgres", null, "menu-item-table", "user"));
 
@@ -166,6 +175,8 @@ public class TableTest extends Base {
   @Test
   void editField() throws InterruptedException {
     go("/");
+    click(tid("database-item"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item")).getDomAttribute("data-database-status")));
 
     click(tid("menu-items", "postgres", null, "menu-item-table", "user"));
 
@@ -182,6 +193,9 @@ public class TableTest extends Base {
   @Test
   void deleteRow() throws InterruptedException {
     go("/");
+    click(tid("database-item"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item")).getDomAttribute("data-database-status")));
+
 
     click(tid("menu-items", "postgres", null, "menu-item-table", "user"));
 
@@ -197,6 +211,9 @@ public class TableTest extends Base {
   @Test
   void filterRow() throws InterruptedException {
     go("/");
+    click(tid("database-item"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item")).getDomAttribute("data-database-status")));
+
 
     click(tid("menu-items", "postgres", null, "menu-item-table", "user"));
 
@@ -213,6 +230,9 @@ public class TableTest extends Base {
   @Test
   void sortRow() throws InterruptedException {
     go("/");
+    click(tid("database-item"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item")).getDomAttribute("data-database-status")));
+
 
     click(tid("menu-items", "postgres", null, "menu-item-table", "user"));
 
@@ -272,6 +292,9 @@ public class TableTest extends Base {
     }
 
     go("/");
+    click(tid("database-item"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item")).getDomAttribute("data-database-status")));
+
 
     click(tid("menu-items", "postgres", null, "menu-item-table", "user"));
 

--- a/desktop/src/main/java/tanin/backdoor/desktop/BackdoorDesktopServer.java
+++ b/desktop/src/main/java/tanin/backdoor/desktop/BackdoorDesktopServer.java
@@ -44,12 +44,11 @@ public class BackdoorDesktopServer extends BackdoorCoreServer {
   public Browser browser;
 
   BackdoorDesktopServer(
-    DatabaseConfig[] databaseConfigs,
     int sslPort,
     String authKey,
     MinumBuilder.KeyStore keyStore
   ) {
-    super(databaseConfigs, -1, sslPort, keyStore);
+    super(new DatabaseConfig[0], -1, sslPort, keyStore);
     this.authKey = authKey;
     this.engineProvider = new EngineProvider();
   }

--- a/desktop/src/main/java/tanin/backdoor/desktop/Main.java
+++ b/desktop/src/main/java/tanin/backdoor/desktop/Main.java
@@ -33,7 +33,6 @@ public class Main {
 
     var authKey = SelfSignedCertificate.generateRandomString(32);
     var server = new BackdoorDesktopServer(
-      new DatabaseConfig[0],
       0,
       authKey,
       new MinumBuilder.KeyStore(keyStoreFile, keyStorePassword)

--- a/desktop/src/test/java/tanin/backdoor/desktop/AdHocDataSourceTest.java
+++ b/desktop/src/test/java/tanin/backdoor/desktop/AdHocDataSourceTest.java
@@ -1,0 +1,99 @@
+package tanin.backdoor.desktop;
+
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.JavascriptExecutor;
+import tanin.backdoor.core.DatabaseConfig;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class AdHocDataSourceTest extends Base {
+  @Test
+  void expand() throws InterruptedException {
+    go("/");
+    assertEquals("unloaded", elem(tid("database-item", "sqlite")).getDomAttribute("data-database-status"));
+    click(tid("database-item", "sqlite"));
+    assertEquals("loaded", elem(tid("database-item", "sqlite")).getDomAttribute("data-database-status"));
+    assertEquals(
+      List.of("user"),
+      elems(tid("menu-items", "sqlite", null, "menu-item-table")).stream().map(e -> e.getDomAttribute("data-test-value")).toList()
+    );
+  }
+
+  @Test
+  void addEditAndDeleteSqlite() throws InterruptedException {
+    go("/");
+    click(tid("add-new-data-source-button"));
+    fill(tid("url"), SQLITE_DATABASE_URL);
+    fill(tid("nickname"), "adhoc-test");
+    fill(tid("username"), "");
+    fill(tid("password"), "");
+    click(tid("submit-button"));
+
+    waitUntil(() -> assertFalse(hasElem(tid("submit-button"))));
+
+    assertEquals(
+      List.of("sqlite", "adhoc-test"),
+      elems(tid("database-item")).stream().map(e -> e.getDomAttribute("data-test-value")).toList()
+    );
+
+    assertEquals("loaded", elem(tid("database-item", "adhoc-test")).getDomAttribute("data-database-status"));
+    assertEquals(
+      List.of("user"),
+      elems(tid("menu-items", "adhoc-test", null, "menu-item-table")).stream().map(e -> e.getDomAttribute("data-test-value")).toList()
+    );
+
+    click(tid("database-item", "adhoc-test", null, "more-option-data-source-button"));
+    click(tid("edit-data-source-button"));
+    fill(tid("nickname"), "adhoc-test-updated");
+    click(tid("submit-button"));
+    waitUntil(() -> assertFalse(hasElem(tid("submit-button"))));
+
+    assertEquals(
+      List.of("sqlite", "adhoc-test-updated"),
+      elems(tid("database-item")).stream().map(e -> e.getDomAttribute("data-test-value")).toList()
+    );
+
+    assertEquals("loaded", elem(tid("database-item", "adhoc-test-updated")).getDomAttribute("data-database-status"));
+    assertEquals(
+      List.of("user"),
+      elems(tid("menu-items", "adhoc-test-updated", null, "menu-item-table")).stream().map(e -> e.getDomAttribute("data-test-value")).toList()
+    );
+
+    click(tid("database-item", "adhoc-test-updated", null, "more-option-data-source-button"));
+    click(tid("delete-data-source-button"));
+    click(tid("submit-button"));
+    waitUntil(() -> assertFalse(hasElem(tid("submit-button"))));
+
+    assertEquals(
+      List.of("sqlite"),
+      elems(tid("database-item")).stream().map(e -> e.getDomAttribute("data-test-value")).toList()
+    );
+  }
+
+  @Test
+  void loadFailedDatabaseAndEdit() throws Exception {
+    server.handleUpdatingAdHocDataSourceConfigs(null, new DatabaseConfig[]{
+      new DatabaseConfig("test-failed", "jdbc:sqlite:read-only.db?open_mode=1", null, null, true)
+    });
+
+    go("/");
+    assertEquals("unloaded", elem(tid("database-item", "test-failed")).getDomAttribute("data-database-status"));
+    click(tid("database-item", "test-failed"));
+    waitUntil(() -> assertContains(
+      elem(tid("edit-data-source-modal")).getText(),
+      "Unable to connect to the data source. Please update the data source's information and try again."
+    ));
+    ((JavascriptExecutor) webDriver).executeScript("window.SET_URL_FOR_TESTING('" + SQLITE_DATABASE_URL + "?open_mode=1')");
+    click(tid("submit-button"));
+    waitUntil(() -> assertFalse(hasElem(tid("submit-button"))));
+
+    assertEquals("loaded", elem(tid("database-item", "test-failed")).getDomAttribute("data-database-status"));
+    assertEquals(
+      List.of("user"),
+      elems(tid("menu-items", "test-failed", null, "menu-item-table")).stream().map(e -> e.getDomAttribute("data-test-value")).toList()
+    );
+  }
+}

--- a/desktop/src/test/java/tanin/backdoor/desktop/HistoryTest.java
+++ b/desktop/src/test/java/tanin/backdoor/desktop/HistoryTest.java
@@ -11,6 +11,9 @@ public class HistoryTest extends Base {
   @Test
   void makeNewSqlAndSearch() throws InterruptedException {
     go("/");
+    click(tid("database-item"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item")).getDomAttribute("data-database-status")));
+
     fillCodeMirror("select 1");
     click(tid("run-sql-button"));
 

--- a/desktop/src/test/java/tanin/backdoor/desktop/sqlite/ExecuteTest.java
+++ b/desktop/src/test/java/tanin/backdoor/desktop/sqlite/ExecuteTest.java
@@ -9,6 +9,9 @@ public class ExecuteTest extends Base {
   @Test
   void runExplain() throws InterruptedException {
     go("/");
+    click(tid("database-item"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item")).getDomAttribute("data-database-status")));
+
     fillCodeMirror("explain select 1");
     click(tid("run-sql-button"));
 
@@ -24,6 +27,9 @@ public class ExecuteTest extends Base {
   @Test
   void updateSql() throws InterruptedException {
     go("/");
+    click(tid("database-item"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item")).getDomAttribute("data-database-status")));
+
     fillCodeMirror("update \"user\" set username = 'test_user_3_updated' where username = 'test_user_3'");
     click(tid("run-sql-button"));
 
@@ -49,6 +55,9 @@ public class ExecuteTest extends Base {
   @Test
   void deleteSql() throws InterruptedException {
     go("/");
+    click(tid("database-item"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item")).getDomAttribute("data-database-status")));
+
     fillCodeMirror("delete from \"user\" where username = 'test_user_3'");
     click(tid("run-sql-button"));
 
@@ -73,6 +82,9 @@ public class ExecuteTest extends Base {
   @Test
   void makeViewAndThenExecute() throws InterruptedException {
     go("/");
+    click(tid("database-item"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item")).getDomAttribute("data-database-status")));
+
     fillCodeMirror("select 1");
     click(tid("run-sql-button"));
 

--- a/desktop/src/test/java/tanin/backdoor/desktop/sqlite/QueryTest.java
+++ b/desktop/src/test/java/tanin/backdoor/desktop/sqlite/QueryTest.java
@@ -9,6 +9,9 @@ public class QueryTest extends Base {
   @Test
   void createRenameUpdateDeleteView() throws InterruptedException {
     go("/");
+    click(tid("database-item"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item")).getDomAttribute("data-database-status")));
+
     fillCodeMirror("select * from \"user\" order by id asc limit 1");
     click(tid("run-sql-button"));
 
@@ -59,6 +62,9 @@ public class QueryTest extends Base {
   @Test
   void makeNewSql() throws InterruptedException {
     go("/");
+    click(tid("database-item"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item")).getDomAttribute("data-database-status")));
+
     fillCodeMirror("select 1");
     click(tid("run-sql-button"));
 

--- a/desktop/src/test/java/tanin/backdoor/desktop/sqlite/TableTest.java
+++ b/desktop/src/test/java/tanin/backdoor/desktop/sqlite/TableTest.java
@@ -86,6 +86,8 @@ public class TableTest extends Base {
   @Test
   void createUpdateDropTable() throws InterruptedException {
     go("/");
+    click(tid("database-item"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item")).getDomAttribute("data-database-status")));
 
     click(tid("menu-items", "sqlite", null, "menu-item-table", "user"));
 
@@ -111,6 +113,8 @@ public class TableTest extends Base {
   @Test
   void editField() throws InterruptedException {
     go("/");
+    click(tid("database-item"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item")).getDomAttribute("data-database-status")));
 
     click(tid("menu-items", "sqlite", null, "menu-item-table", "user"));
 
@@ -127,6 +131,8 @@ public class TableTest extends Base {
   @Test
   void deleteRow() throws InterruptedException {
     go("/");
+    click(tid("database-item"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item")).getDomAttribute("data-database-status")));
 
     click(tid("menu-items", "sqlite", null, "menu-item-table", "user"));
 
@@ -142,6 +148,8 @@ public class TableTest extends Base {
   @Test
   void filterRow() throws InterruptedException {
     go("/");
+    click(tid("database-item"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item")).getDomAttribute("data-database-status")));
 
     click(tid("menu-items", "sqlite", null, "menu-item-table", "user"));
 
@@ -158,6 +166,8 @@ public class TableTest extends Base {
   @Test
   void sortRow() throws InterruptedException {
     go("/");
+    click(tid("database-item"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item")).getDomAttribute("data-database-status")));
 
     click(tid("menu-items", "sqlite", null, "menu-item-table", "user"));
 
@@ -217,6 +227,8 @@ public class TableTest extends Base {
     }
 
     go("/");
+    click(tid("database-item"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item")).getDomAttribute("data-database-status")));
 
     click(tid("menu-items", "sqlite", null, "menu-item-table", "user"));
 

--- a/frontend/svelte/_additional_login_modal.svelte
+++ b/frontend/svelte/_additional_login_modal.svelte
@@ -7,7 +7,7 @@ import ErrorPanel from "./common/form/_error_panel.svelte"
 import 'altcha'
 import {trackEvent} from "./common/tracker";
 
-export let onLoggedIn: () => Promise<void>
+export let onLoading: (database: Database) => Promise<void>
 
 let modal: HTMLDialogElement;
 let usernameInput: HTMLInputElement;
@@ -63,9 +63,9 @@ async function submit() {
       ...form
     })
 
-    await onLoggedIn()
-    modal.close()
     trackEvent('data-source-logged-in')
+    await onLoading(database_!)
+    modal.close()
   } catch (e) {
     isLoading = false
     errors = (e as FetchError).messages
@@ -78,7 +78,7 @@ async function submit() {
 <dialog
   bind:this={modal}
   class="modal2"
-  data-test-id="edit-modal"
+  data-test-id="additional-login-modal"
 >
   <div class="modal-box !max-w-[480px] !w-auto flex flex-col gap-4" onkeydown={invokeOnEnter(submit)}>
     <div class="text-neutral-content text-sm">

--- a/frontend/svelte/_editor_panel.svelte
+++ b/frontend/svelte/_editor_panel.svelte
@@ -25,7 +25,7 @@ let historyModal: HistoryModal
 let validDatabases: Database[] = []
 
 $: {
-  validDatabases = databases.filter(d => !d.requireLogin)
+  validDatabases = databases.filter(d => d.status === 'loaded')
 }
 
 $: if (validDatabases.length > 0 && !selectedDatabaseName) {

--- a/frontend/svelte/_new_data_source_modal.svelte
+++ b/frontend/svelte/_new_data_source_modal.svelte
@@ -8,7 +8,7 @@ import {trackEvent} from "./common/tracker";
 import {openFileDialog, PARADIGM} from "./common/globals";
 import type {DatabaseType} from "./common/models";
 
-export let onAdded: () => Promise<void>
+export let onAdded: (nickname: string) => Promise<void>
 
 let modal: HTMLDialogElement;
 let mainInput: HTMLInputElement;
@@ -61,7 +61,7 @@ async function submit() {
   try {
     const json = await post('/api/add-data-source', form)
 
-    await onAdded()
+    await onAdded(form.nickname)
     modal.close()
     trackEvent('new-data-source-added')
   } catch (e) {

--- a/frontend/svelte/common/models.ts
+++ b/frontend/svelte/common/models.ts
@@ -9,7 +9,6 @@ export interface DatabaseAdHocInfo {
 export interface Database {
   nickname: string;
   isAdHoc: boolean;
-  requireLogin: boolean;
   tables: string[];
   adHocInfo: DatabaseAdHocInfo | null;
   status: 'loaded' | 'unloaded'

--- a/web/src/test/java/tanin/backdoor/web/AdHocDataSourceTest.java
+++ b/web/src/test/java/tanin/backdoor/web/AdHocDataSourceTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class AdHocDataSourceTest extends Base {
   @Test
-  void addEditAndDeletePostgres() throws InterruptedException {
+  void addExpandEditAndDeletePostgres() throws InterruptedException {
     go("/");
     click(tid("add-new-data-source-button"));
     fill(tid("url"), "postgres://backdoor_test_user:test@127.0.0.1:5432/backdoor_test");
@@ -22,8 +22,9 @@ public class AdHocDataSourceTest extends Base {
 
     assertEquals(
       List.of("postgres", "clickhouse", "adhoc-test"),
-      elems(tid("menu-items")).stream().map(e -> e.getDomAttribute("data-test-value")).toList()
+      elems(tid("database-item")).stream().map(e -> e.getDomAttribute("data-test-value")).toList()
     );
+
     assertEquals(
       List.of("user"),
       elems(tid("menu-items", "adhoc-test", null, "menu-item-table")).stream().map(e -> e.getDomAttribute("data-test-value")).toList()
@@ -37,8 +38,14 @@ public class AdHocDataSourceTest extends Base {
 
     assertEquals(
       List.of("postgres", "clickhouse", "adhoc-test-updated"),
-      elems(tid("menu-items")).stream().map(e -> e.getDomAttribute("data-test-value")).toList()
+      elems(tid("database-item")).stream().map(e -> e.getDomAttribute("data-test-value")).toList()
     );
+
+    assertEquals(
+      List.of("user"),
+      elems(tid("menu-items", "adhoc-test-updated", null, "menu-item-table")).stream().map(e -> e.getDomAttribute("data-test-value")).toList()
+    );
+
 
     click(tid("more-option-data-source-button"));
     click(tid("delete-data-source-button"));
@@ -47,7 +54,7 @@ public class AdHocDataSourceTest extends Base {
 
     assertEquals(
       List.of("postgres", "clickhouse"),
-      elems(tid("menu-items")).stream().map(e -> e.getDomAttribute("data-test-value")).toList()
+      elems(tid("database-item")).stream().map(e -> e.getDomAttribute("data-test-value")).toList()
     );
   }
 
@@ -65,8 +72,9 @@ public class AdHocDataSourceTest extends Base {
 
     assertEquals(
       List.of("postgres", "clickhouse", "adhoc-test"),
-      elems(tid("menu-items")).stream().map(e -> e.getDomAttribute("data-test-value")).toList()
+      elems(tid("database-item")).stream().map(e -> e.getDomAttribute("data-test-value")).toList()
     );
+
     assertEquals(
       List.of("project_setting"),
       elems(tid("menu-items", "adhoc-test", null, "menu-item-table")).stream().map(e -> e.getDomAttribute("data-test-value")).toList()

--- a/web/src/test/java/tanin/backdoor/web/HistoryTest.java
+++ b/web/src/test/java/tanin/backdoor/web/HistoryTest.java
@@ -11,6 +11,9 @@ public class HistoryTest extends Base {
   @Test
   void makeNewSqlAndSearch() throws InterruptedException {
     go("/");
+    click(tid("database-item"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item")).getDomAttribute("data-database-status")));
+
     fillCodeMirror("select 1");
     click(tid("run-sql-button"));
 

--- a/web/src/test/java/tanin/backdoor/web/LoginAdditionalTest.java
+++ b/web/src/test/java/tanin/backdoor/web/LoginAdditionalTest.java
@@ -39,7 +39,7 @@ public class LoginAdditionalTest extends Base {
     ));
     go("/");
 
-    click(tid("database-lock-item", "clickhouse"));
+    click(tid("database-item", "clickhouse"));
   }
 
   @Test

--- a/web/src/test/java/tanin/backdoor/web/LoginTest.java
+++ b/web/src/test/java/tanin/backdoor/web/LoginTest.java
@@ -44,6 +44,8 @@ public class LoginTest extends Base {
     click(tid("submit-button"));
 
     waitUntil(() -> assertEquals("/", getCurrentPath()));
+    click(tid("database-item"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item")).getDomAttribute("data-database-status")));
 
     fillCodeMirror("select current_user");
     click(tid("run-sql-button"));
@@ -95,12 +97,16 @@ public class LoginTest extends Base {
 
     waitUntil(() -> assertEquals("/", getCurrentPath()));
 
+    click(tid("database-item", "postgres"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item", "postgres")).getDomAttribute("data-database-status")));
     assertEquals(
       List.of("user"),
       elems(tid("menu-items", "postgres", null, "menu-item-table")).stream().map(e -> e.getDomAttribute("data-test-value")).toList()
     );
 
-    assertTrue(hasElem(tid("database-lock-item", "clickhouse")));
+    assertEquals("unloaded", elem(tid("database-item", "clickhouse")).getDomAttribute("data-database-status"));
+    click(tid("database-item", "clickhouse"));
+    waitUntil(() -> assertTrue(hasElem(tid("additional-login-modal"))));
   }
 
   @Test
@@ -135,10 +141,14 @@ public class LoginTest extends Base {
 
     waitUntil(() -> assertEquals("/", getCurrentPath()));
 
+    click(tid("database-item", "postgres"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item", "postgres")).getDomAttribute("data-database-status")));
     assertEquals(
       List.of("user"),
       elems(tid("menu-items", "postgres", null, "menu-item-table")).stream().map(e -> e.getDomAttribute("data-test-value")).toList()
     );
+    click(tid("database-item", "clickhouse"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item", "clickhouse")).getDomAttribute("data-database-status")));
     assertEquals(
       List.of("project_setting"),
       elems(tid("menu-items", "clickhouse", null, "menu-item-table")).stream().map(e -> e.getDomAttribute("data-test-value")).toList()
@@ -177,10 +187,14 @@ public class LoginTest extends Base {
 
     waitUntil(() -> assertEquals("/", getCurrentPath()));
 
+    click(tid("database-item", "postgres"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item", "postgres")).getDomAttribute("data-database-status")));
     assertEquals(
       List.of("user"),
       elems(tid("menu-items", "postgres", null, "menu-item-table")).stream().map(e -> e.getDomAttribute("data-test-value")).toList()
     );
+    click(tid("database-item", "clickhouse"));
+    waitUntil(() -> assertEquals("loaded", elem(tid("database-item", "clickhouse")).getDomAttribute("data-database-status")));
     assertEquals(
       List.of("project_setting"),
       elems(tid("menu-items", "clickhouse", null, "menu-item-table")).stream().map(e -> e.getDomAttribute("data-test-value")).toList()


### PR DESCRIPTION
In the cases where some databases become invalid, the initial load would still work. The initial start is also faster because we don't have to reach out to every database before loading the first screen.